### PR TITLE
feat(category): add category module with CRUD operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -7,6 +7,7 @@ import { MongooseModule } from '@nestjs/mongoose';
 import { AuthModule } from './auth/auth.module';
 import configuration from './config/configuration';
 import { JwtModule } from './common/jwt/jwt.module';
+import { CategoryModule } from './category/category.module';
 
 @Module({
   imports: [
@@ -24,6 +25,7 @@ import { JwtModule } from './common/jwt/jwt.module';
     UserModule,
     AuthModule,
     JwtModule,
+    CategoryModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/category/category.controller.spec.ts
+++ b/src/category/category.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryController } from './category.controller';
+import { CategoryService } from './category.service';
+
+describe('CategoryController', () => {
+  let controller: CategoryController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CategoryController],
+      providers: [CategoryService],
+    }).compile();
+
+    controller = module.get<CategoryController>(CategoryController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -1,0 +1,47 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  UseGuards,
+} from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { AuthGuard } from 'src/auth/guards/auth.guard';
+import { Role } from 'src/auth/decorators/roles.decorator';
+import { Roles } from 'src/enum';
+
+@Controller('category')
+export class CategoryController {
+  constructor(private readonly categoryService: CategoryService) {}
+
+  @Post()
+  @UseGuards(AuthGuard)
+  @Role(Roles.ADMIN)
+  create(@Body() createCategoryDto: CreateCategoryDto) {
+    return this.categoryService.create(createCategoryDto);
+  }
+
+  @Get()
+  findAll() {
+    return this.categoryService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string) {
+    return this.categoryService.findOne(id);
+  }
+
+  @Patch(':id')
+  @UseGuards(AuthGuard)
+  @Role(Roles.ADMIN)
+  update(
+    @Param('id') id: string,
+    @Body() updateCategoryDto: UpdateCategoryDto,
+  ) {
+    return this.categoryService.update(id, updateCategoryDto);
+  }
+}

--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { CategoryService } from './category.service';
+import { CategoryController } from './category.controller';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Category, CategorySchema } from './schema/category.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([
+      { name: Category.name, schema: CategorySchema },
+    ]),
+  ],
+  controllers: [CategoryController],
+  providers: [CategoryService],
+})
+export class CategoryModule {}

--- a/src/category/category.service.spec.ts
+++ b/src/category/category.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CategoryService } from './category.service';
+
+describe('CategoryService', () => {
+  let service: CategoryService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [CategoryService],
+    }).compile();
+
+    service = module.get<CategoryService>(CategoryService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -1,0 +1,59 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CreateCategoryDto } from './dto/create-category.dto';
+import { UpdateCategoryDto } from './dto/update-category.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Category, CategoryDocument } from './schema/category.schema';
+import { Model } from 'mongoose';
+
+@Injectable()
+export class CategoryService {
+  constructor(
+    @InjectModel(Category.name) private categoryModel: Model<Category>,
+  ) {}
+
+  async create(
+    createCategoryDto: CreateCategoryDto,
+  ): Promise<CategoryDocument> {
+    const category = await this.categoryModel.findOne({
+      name: createCategoryDto.name,
+    });
+
+    if (category) {
+      throw new HttpException(
+        'Category already exists',
+        HttpStatus.BAD_REQUEST,
+      );
+    }
+    const newCategory = new this.categoryModel(createCategoryDto);
+    return newCategory.save();
+  }
+
+  async findAll(): Promise<CategoryDocument[]> {
+    return await this.categoryModel.find();
+  }
+
+  async findOne(id: string): Promise<CategoryDocument> {
+    const category = await this.categoryModel.findById(id);
+
+    if (!category) {
+      throw new HttpException('Category not found', HttpStatus.NOT_FOUND);
+    }
+
+    return category;
+  }
+
+  async update(
+    id: string,
+    updateCategoryDto: UpdateCategoryDto,
+  ): Promise<CategoryDocument> {
+    const category = await this.categoryModel.findById(id);
+
+    if (!category) {
+      throw new HttpException('Category not found', HttpStatus.NOT_FOUND);
+    }
+
+    return (await this.categoryModel.findByIdAndUpdate(id, updateCategoryDto, {
+      new: true,
+    })) as CategoryDocument;
+  }
+}

--- a/src/category/dto/create-category.dto.ts
+++ b/src/category/dto/create-category.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsBoolean,
+  IsDate,
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  MinLength,
+} from 'class-validator';
+
+export class CreateCategoryDto {
+  @IsString({ message: 'Name must be a string' })
+  @IsNotEmpty({ message: 'Name is required' })
+  @MinLength(3, { message: 'Name must be at least 3 characters long' })
+  name: string;
+
+  @IsString({ message: 'Description must be a string' })
+  @IsNotEmpty({ message: 'Description is required' })
+  @MinLength(3, { message: 'Description must be at least 3 characters long' })
+  description: string;
+
+  @IsBoolean({ message: 'IsActive must be a boolean' })
+  @IsOptional()
+  isActive: boolean;
+
+  @IsDate({ message: 'DeletedAt must be a date' })
+  @IsOptional()
+  deletedAt: Date;
+}

--- a/src/category/dto/update-category.dto.ts
+++ b/src/category/dto/update-category.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateCategoryDto } from './create-category.dto';
+
+export class UpdateCategoryDto extends PartialType(CreateCategoryDto) {}

--- a/src/category/schema/category.schema.ts
+++ b/src/category/schema/category.schema.ts
@@ -1,0 +1,26 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import { HydratedDocument } from 'mongoose';
+
+export type CategoryDocument = HydratedDocument<Category>;
+
+@Schema({
+  collection: 'categories',
+  timestamps: true,
+  versionKey: false,
+})
+export class Category {
+  _id: string;
+  @Prop({ required: true, type: String, trim: true })
+  name: string;
+
+  @Prop({ required: true, type: String, trim: true })
+  description: string;
+
+  @Prop({ default: true, type: Boolean })
+  isActive: boolean;
+
+  @Prop({ type: Date, default: null })
+  deletedAt: Date;
+}
+
+export const CategorySchema = SchemaFactory.createForClass(Category);


### PR DESCRIPTION
Introduce a new category module with full CRUD functionality, including DTOs, schema, service, controller, and tests. The module integrates with MongoDB via Mongoose and includes role-based access control for admin operations.