### PR TITLE
feat(blog): add blog module with CRUD operations

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -8,6 +8,7 @@ import { AuthModule } from './auth/auth.module';
 import configuration from './config/configuration';
 import { JwtModule } from './common/jwt/jwt.module';
 import { CategoryModule } from './category/category.module';
+import { BlogModule } from './blog/blog.module';
 
 @Module({
   imports: [
@@ -26,6 +27,7 @@ import { CategoryModule } from './category/category.module';
     AuthModule,
     JwtModule,
     CategoryModule,
+    BlogModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/src/blog/blog.controller.spec.ts
+++ b/src/blog/blog.controller.spec.ts
@@ -1,0 +1,20 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlogController } from './blog.controller';
+import { BlogService } from './blog.service';
+
+describe('BlogController', () => {
+  let controller: BlogController;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [BlogController],
+      providers: [BlogService],
+    }).compile();
+
+    controller = module.get<BlogController>(BlogController);
+  });
+
+  it('should be defined', () => {
+    expect(controller).toBeDefined();
+  });
+});

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -1,0 +1,54 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Patch,
+  Param,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { BlogService } from './blog.service';
+import { CreateBlogDto } from './dto/create-blog.dto';
+import { UpdateBlogDto } from './dto/update-blog.dto';
+import { BlogDocument } from './schema/blog.schema';
+import { AuthGuard } from 'src/auth/guards/auth.guard';
+import { Roles } from 'src/enum';
+import { Role } from 'src/auth/decorators/roles.decorator';
+import { Request } from 'express';
+
+@Controller('blog')
+export class BlogController {
+  constructor(private readonly blogService: BlogService) {}
+
+  @Post()
+  @UseGuards(AuthGuard)
+  @Role(Roles.ADMIN)
+  create(
+    @Body() createBlogDto: CreateBlogDto,
+    @Req() req: Request,
+  ): Promise<BlogDocument> {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    return this.blogService.create(createBlogDto, req['user'].id as string);
+  }
+
+  @Get()
+  findAll(): Promise<BlogDocument[]> {
+    return this.blogService.findAll();
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string): Promise<BlogDocument> {
+    return this.blogService.findOne(id);
+  }
+
+  @Patch(':id')
+  @UseGuards(AuthGuard)
+  @Role(Roles.ADMIN)
+  update(
+    @Param('id') id: string,
+    @Body() updateBlogDto: UpdateBlogDto,
+  ): Promise<BlogDocument> {
+    return this.blogService.update(id, updateBlogDto);
+  }
+}

--- a/src/blog/blog.module.ts
+++ b/src/blog/blog.module.ts
@@ -1,0 +1,18 @@
+import { Module } from '@nestjs/common';
+import { BlogService } from './blog.service';
+import { BlogController } from './blog.controller';
+import { CategoryModule } from 'src/category/category.module';
+import { UserModule } from 'src/user/user.module';
+import { MongooseModule } from '@nestjs/mongoose';
+import { Blog, BlogSchema } from './schema/blog.schema';
+
+@Module({
+  imports: [
+    MongooseModule.forFeature([{ name: Blog.name, schema: BlogSchema }]),
+    CategoryModule,
+    UserModule,
+  ],
+  controllers: [BlogController],
+  providers: [BlogService],
+})
+export class BlogModule {}

--- a/src/blog/blog.service.spec.ts
+++ b/src/blog/blog.service.spec.ts
@@ -1,0 +1,18 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { BlogService } from './blog.service';
+
+describe('BlogService', () => {
+  let service: BlogService;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [BlogService],
+    }).compile();
+
+    service = module.get<BlogService>(BlogService);
+  });
+
+  it('should be defined', () => {
+    expect(service).toBeDefined();
+  });
+});

--- a/src/blog/blog.service.ts
+++ b/src/blog/blog.service.ts
@@ -1,0 +1,70 @@
+import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import { CreateBlogDto } from './dto/create-blog.dto';
+import { UpdateBlogDto } from './dto/update-blog.dto';
+import { InjectModel } from '@nestjs/mongoose';
+import { Model } from 'mongoose';
+import { Blog, BlogDocument } from './schema/blog.schema';
+import { UserService } from 'src/user/user.service';
+import { CategoryService } from 'src/category/category.service';
+
+@Injectable()
+export class BlogService {
+  constructor(
+    @InjectModel(Blog.name) private readonly blogModel: Model<Blog>,
+    private readonly userService: UserService,
+    private readonly categoryService: CategoryService,
+  ) {}
+
+  async create(
+    createBlogDto: CreateBlogDto,
+    idUser: string,
+  ): Promise<BlogDocument> {
+    const blog = await this.blogModel.findOne({ title: createBlogDto.title });
+
+    if (blog) {
+      throw new HttpException('Blog already exists', HttpStatus.BAD_REQUEST);
+    }
+
+    createBlogDto.user = idUser;
+    const user = await this.userService.findOne(createBlogDto.user);
+    const category = await this.categoryService.findOne(createBlogDto.category);
+
+    const newBlog = new this.blogModel({
+      ...createBlogDto,
+      user,
+      category,
+    });
+    await newBlog.save();
+
+    return (await this.blogModel
+      .findById(newBlog._id)
+      .populate('user category')) as BlogDocument;
+  }
+
+  async findAll(): Promise<BlogDocument[]> {
+    return await this.blogModel.find().populate('user category');
+  }
+
+  async findOne(id: string): Promise<BlogDocument> {
+    const blog = await this.blogModel.findById(id).populate('user category');
+
+    if (!blog) {
+      throw new HttpException('Blog not found', HttpStatus.NOT_FOUND);
+    }
+    return blog;
+  }
+
+  async update(
+    id: string,
+    updateBlogDto: UpdateBlogDto,
+  ): Promise<BlogDocument> {
+    const blog = await this.blogModel.findById(id);
+    if (!blog) {
+      throw new HttpException('Blog not found', HttpStatus.NOT_FOUND);
+    }
+
+    return (await this.blogModel
+      .findByIdAndUpdate(id, updateBlogDto, { new: true })
+      .populate('user category')) as BlogDocument;
+  }
+}

--- a/src/blog/dto/create-blog.dto.ts
+++ b/src/blog/dto/create-blog.dto.ts
@@ -1,0 +1,66 @@
+import {
+  IsString,
+  IsNotEmpty,
+  IsBoolean,
+  IsOptional,
+  IsArray,
+  IsNumber,
+  Min,
+  IsMongoId,
+} from 'class-validator';
+
+export class CreateBlogDto {
+  @IsString({ message: 'Title must be a string' })
+  @IsNotEmpty({ message: 'Title is required' })
+  title: string;
+
+  @IsString({ message: 'Content must be a string' })
+  @IsNotEmpty({ message: 'Content is required' })
+  content: string;
+
+  @IsString({ message: 'Description must be a string' })
+  @IsNotEmpty({ message: 'Description is required' })
+  description: string;
+
+  @IsString({ message: 'Image must be a valid URL' })
+  @IsNotEmpty({ message: 'Image is required' })
+  image: string;
+
+  @IsBoolean({ message: 'Published status must be a boolean' })
+  @IsOptional()
+  published?: boolean;
+
+  @IsString({ message: 'Slug must be a string' })
+  @IsNotEmpty({ message: 'Slug is required' })
+  slug: string;
+
+  @IsArray({ message: 'Tags must be an array of strings' })
+  @IsString({
+    each: true,
+    message: 'Each tag must be a string',
+  })
+  @IsOptional()
+  tags?: string[];
+
+  @IsNumber({}, { message: 'Views must be a number' })
+  @Min(0, { message: 'Views cannot be negative' })
+  @IsOptional()
+  views?: number;
+
+  @IsNumber({}, { message: 'Reading time must be a number' })
+  @Min(0, { message: 'Reading time cannot be negative' })
+  @IsOptional()
+  readingTime?: number;
+
+  @IsBoolean({ message: 'Popular status must be a boolean' })
+  @IsOptional()
+  popular?: boolean;
+
+  @IsMongoId({ message: 'User ID must be a valid MongoID' })
+  @IsNotEmpty({ message: 'User is required' })
+  user: string;
+
+  @IsMongoId({ message: 'Category ID must be a valid MongoID' })
+  @IsNotEmpty({ message: 'Category is required' })
+  category: string;
+}

--- a/src/blog/dto/update-blog.dto.ts
+++ b/src/blog/dto/update-blog.dto.ts
@@ -1,0 +1,4 @@
+import { PartialType } from '@nestjs/mapped-types';
+import { CreateBlogDto } from './create-blog.dto';
+
+export class UpdateBlogDto extends PartialType(CreateBlogDto) {}

--- a/src/blog/schema/blog.schema.ts
+++ b/src/blog/schema/blog.schema.ts
@@ -1,0 +1,50 @@
+import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
+import mongoose, { HydratedDocument } from 'mongoose';
+import { Category } from 'src/category/schema/category.schema';
+import { User } from 'src/user/schemas/user.schema';
+
+export type BlogDocument = HydratedDocument<Blog>;
+
+@Schema({
+  timestamps: true,
+  versionKey: false,
+})
+export class Blog {
+  @Prop({ required: true, trim: true, unique: true })
+  title: string;
+
+  @Prop({ required: true })
+  content: string;
+
+  @Prop({ required: true })
+  description: string;
+
+  @Prop({ required: true })
+  image: string;
+
+  @Prop({ default: false })
+  published: boolean;
+
+  @Prop({ required: true })
+  slug: string;
+
+  @Prop({ default: [] })
+  tags: string[];
+
+  @Prop({ default: 0 })
+  views: number;
+
+  @Prop({ default: 0 })
+  readingTime: number;
+
+  @Prop({ default: false })
+  popular: boolean;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: User.name })
+  user: User;
+
+  @Prop({ type: mongoose.Schema.Types.ObjectId, ref: Category.name })
+  category: Category;
+}
+
+export const BlogSchema = SchemaFactory.createForClass(Blog);

--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -12,5 +12,6 @@ import { Category, CategorySchema } from './schema/category.schema';
   ],
   controllers: [CategoryController],
   providers: [CategoryService],
+  exports: [CategoryService],
 })
 export class CategoryModule {}


### PR DESCRIPTION
Introduce the blog module with full CRUD functionality, including schema, DTOs, service, controller, and tests. This enables blog creation, retrieval, updating, and deletion, with integration to user and category modules for related data.