### PR TITLE
Feature/paginate

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "class-transformer": "0.5.1",
         "class-validator": "0.14.1",
         "mongoose": "8.13.2",
+        "mongoose-paginate-v2": "1.9.0",
         "reflect-metadata": "^0.2.2",
         "rxjs": "^7.8.1"
       },
@@ -9109,6 +9110,42 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mongoose"
+      }
+    },
+    "node_modules/mongoose-lean-virtuals": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/mongoose-lean-virtuals/-/mongoose-lean-virtuals-1.1.0.tgz",
+      "integrity": "sha512-QCuAvPUTGzUMjbvWqhA+3hXX7hP0PPJOW+hm50KN3gTPM89Uan/wrFyCfvsqW9giAGemtIFsBrZwiogmu2gxmA==",
+      "license": "Apache 2.0",
+      "dependencies": {
+        "mpath": "^0.8.4"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "mongoose": ">=5.11.10"
+      }
+    },
+    "node_modules/mongoose-lean-virtuals/node_modules/mpath": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/mongoose-paginate-v2": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/mongoose-paginate-v2/-/mongoose-paginate-v2-1.9.0.tgz",
+      "integrity": "sha512-al4rsqadzg4TXcJVWI5WSaNUuSpzdtcPbabwXxbA7Euh6swuLkrrHrBmlGI6d3I4RMStdRAoD7k6wvB/x5zvaw==",
+      "license": "MIT",
+      "dependencies": {
+        "mongoose-lean-virtuals": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mpath": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "class-transformer": "0.5.1",
     "class-validator": "0.14.1",
     "mongoose": "8.13.2",
+    "mongoose-paginate-v2": "1.9.0",
     "reflect-metadata": "^0.2.2",
     "rxjs": "^7.8.1"
   },

--- a/src/blog/blog.controller.ts
+++ b/src/blog/blog.controller.ts
@@ -7,6 +7,7 @@ import {
   Param,
   UseGuards,
   Req,
+  Query,
 } from '@nestjs/common';
 import { BlogService } from './blog.service';
 import { CreateBlogDto } from './dto/create-blog.dto';
@@ -33,8 +34,14 @@ export class BlogController {
   }
 
   @Get()
-  findAll(): Promise<BlogDocument[]> {
-    return this.blogService.findAll();
+  findAll(
+    @Query('page') page: number = 1,
+    @Query('limit') limit: number = 10,
+    @Query('search') search: string = '',
+    @Query('published') published?: boolean,
+    @Query('popular') popular?: boolean,
+  ) {
+    return this.blogService.findAll(page, limit, search, published, popular);
   }
 
   @Get(':id')

--- a/src/blog/schema/blog.schema.ts
+++ b/src/blog/schema/blog.schema.ts
@@ -2,6 +2,7 @@ import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import mongoose, { HydratedDocument } from 'mongoose';
 import { Category } from 'src/category/schema/category.schema';
 import { User } from 'src/user/schemas/user.schema';
+import * as mongoosePaginate from 'mongoose-paginate-v2';
 
 export type BlogDocument = HydratedDocument<Blog>;
 
@@ -47,4 +48,6 @@ export class Blog {
   category: Category;
 }
 
-export const BlogSchema = SchemaFactory.createForClass(Blog);
+const BlogSchema = SchemaFactory.createForClass(Blog);
+BlogSchema.plugin(mongoosePaginate);
+export { BlogSchema };

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -35,7 +35,9 @@ export class UserService {
   }
 
   async findAll(): Promise<UserDocumentWithoutPassword[]> {
-    return await this.userModel.find().select('-password');
+    return (await this.userModel
+      .find()
+      .select('-password')) as UserDocumentWithoutPassword[];
   }
 
   async findOne(id: string): Promise<UserDocumentWithoutPassword> {


### PR DESCRIPTION
This commit introduces pagination and search capabilities to the blog listings. The `mongoose-paginate-v2` package was added to handle pagination efficiently. The `findAll` method in the blog service was updated to support pagination, search, and filtering by `published` and `popular` status. The blog controller was also modified to accept query parameters for page, limit, search, and filters.