### PR TITLE
Update CORS to allow all origins

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -24,7 +24,7 @@ async function bootstrap() {
 
   app.useGlobalPipes(new ValidationPipe());
   app.use(helmet());
-  app.use(cors({ credentials: true }));
+  app.use(cors({ origin: '*', credentials: true }));
   app.use(cookieParser());
   await app.listen(process.env.PORT ?? 3000);
 }


### PR DESCRIPTION
```
### Description
Updated the CORS configuration to permit requests from all origins by setting `origin: '*'`. This ensures enhanced flexibility for cross-origin requests while maintaining credentials support.

### Type of change
- [x] Bug fix (non-breaking change addressing an issue)
- [ ]