### PR TITLE
Add localhost:3001 to CORS allowed origins

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -28,6 +28,7 @@ async function bootstrap() {
     'http://localhost:3000',
     'https://blog-jonathanleivag.vercel.app',
     'https://blog.jonathanleivag.cl',
+    'http://localhost:3001',
   ];
   app.use(
     cors({


### PR DESCRIPTION
This pull request updates the CORS configuration to ensure requests from `http://localhost:3001` are allowed. It facilitates development and testing by enabling the application to accept requests from this origin.