### PR TITLE
Update QA environment and refine cookie domain settings

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -34,7 +34,9 @@ export class AuthController {
       secure: this.configService.get<string>('node.NODE_ENV') === 'production',
       sameSite: this.configService.get<string>('node.SAMESITE') as SAMESITE,
       maxAge: 1000 * 60 * 60 * 24 * 30,
-      domain: `.${this.configService.get<string>('uri.URI')}`,
+      ...(process.env.NODE_ENV === 'production' && {
+        domain: `.${this.configService.get<string>('uri.URI')}`,
+      }),
     });
     return response;
   }
@@ -50,7 +52,9 @@ export class AuthController {
       secure: this.configService.get<string>('node.NODE_ENV') === 'production',
       sameSite: this.configService.get<string>('node.SAMESITE') as SAMESITE,
       maxAge: 1000 * 60 * 60 * 24 * 30,
-      domain: `.${this.configService.get<string>('uri.URI')}`,
+      ...(process.env.NODE_ENV === 'production' && {
+        domain: `.${this.configService.get<string>('uri.URI')}`,
+      }),
     });
     return register;
   }
@@ -71,7 +75,9 @@ export class AuthController {
       secure: this.configService.get<string>('node.NODE_ENV') === 'production',
       sameSite: this.configService.get<string>('node.SAMESITE') as SAMESITE,
       maxAge: 1000 * 60 * 60 * 24 * 30,
-      domain: `.${this.configService.get<string>('uri.URI')}`,
+      ...(process.env.NODE_ENV === 'production' && {
+        domain: `.${this.configService.get<string>('uri.URI')}`,
+      }),
     });
 
     return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -31,6 +31,7 @@ async function bootstrap() {
     'https://jonathanleivag.cl',
     'http://localhost:3001',
     'http://localhost:4321',
+    'https://qa-blog.jonathanleivag.cl',
   ];
   app.use(
     cors({


### PR DESCRIPTION
Improved environment flexibility by adding a QA blog URL to allowed CORS origins. Adjusted cookie settings to conditionally set the domain key only in production.